### PR TITLE
create P_Gate/Meta/Label tag

### DIFF
--- a/tags/udt_types_/FactoryPacks/P_Gate.json
+++ b/tags/udt_types_/FactoryPacks/P_Gate.json
@@ -78,6 +78,59 @@
     {
       "opcItemPath": {
         "bindType": "parameter",
+        "binding": "[{PLC}]{PAX Tag}.Out"
+      },
+      "opcServer": {
+        "bindType": "parameter",
+        "binding": "{OPC Server}"
+      },
+      "accessRights": "Read_Only",
+      "valueSource": "opc",
+      "dataType": "Boolean",
+      "name": "Out",
+      "tagGroup": "FactoryPacks Leased",
+      "value": false,
+      "tagType": "AtomicTag"
+    },
+    {
+      "name": "Meta",
+      "tagType": "Folder",
+      "tags": [
+        {
+          "valueSource": "expr",
+          "expression": "// If this tag is nested in a parent device udt (P_VSD for instance)\r\n// then prepend the parent label to the gate label,\r\n// otherwise just use the gate label\r\n\r\nif(isGood({[.]../../../Meta/Label}),\r\n\t{[.]../../../Meta/Label} + \" \" + {[.]../Config/GateCond},\r\n\t{[.]../Config/GateCond}\r\n)",
+          "dataType": "String",
+          "name": "Label",
+          "tagType": "AtomicTag"
+        }
+      ]
+    },
+    {
+      "name": "Input",
+      "tagType": "Folder",
+      "tags": [
+        {
+          "opcItemPath": {
+            "bindType": "parameter",
+            "binding": "[{PLC}]{PAX Tag}.Inp_Gate"
+          },
+          "opcServer": {
+            "bindType": "parameter",
+            "binding": "{OPC Server}"
+          },
+          "accessRights": "Read_Only",
+          "valueSource": "opc",
+          "dataType": "Boolean",
+          "name": "Gate",
+          "tagGroup": "FactoryPacks Leased",
+          "value": false,
+          "tagType": "AtomicTag"
+        }
+      ]
+    },
+    {
+      "opcItemPath": {
+        "bindType": "parameter",
         "binding": "[{PLC}]{PAX Tag}.Inp"
       },
       "opcServer": {
@@ -192,46 +245,6 @@
           "name": "GateDly",
           "value": 0.0,
           "engUnit": "s",
-          "tagType": "AtomicTag"
-        }
-      ]
-    },
-    {
-      "opcItemPath": {
-        "bindType": "parameter",
-        "binding": "[{PLC}]{PAX Tag}.Out"
-      },
-      "opcServer": {
-        "bindType": "parameter",
-        "binding": "{OPC Server}"
-      },
-      "accessRights": "Read_Only",
-      "valueSource": "opc",
-      "dataType": "Boolean",
-      "name": "Out",
-      "tagGroup": "FactoryPacks Leased",
-      "value": false,
-      "tagType": "AtomicTag"
-    },
-    {
-      "name": "Input",
-      "tagType": "Folder",
-      "tags": [
-        {
-          "opcItemPath": {
-            "bindType": "parameter",
-            "binding": "[{PLC}]{PAX Tag}.Inp_Gate"
-          },
-          "opcServer": {
-            "bindType": "parameter",
-            "binding": "{OPC Server}"
-          },
-          "accessRights": "Read_Only",
-          "valueSource": "opc",
-          "dataType": "Boolean",
-          "name": "Gate",
-          "tagGroup": "FactoryPacks Leased",
-          "value": false,
           "tagType": "AtomicTag"
         }
       ]


### PR DESCRIPTION
The new tag references existing tags, so it does not need extra configuration. See the expression below for P_Gate/Meta/Label:

// If this tag is nested in a parent device udt (P_VSD for instance)
// then prepend the parent label to the gate label,
// otherwise just use the gate label

if(isGood({[.]../../../Meta/Label}),
	{[.]../../../Meta/Label} + " " + {[.]../Config/GateCond},
	{[.]../Config/GateCond}
)

This fixes the "null" label description on the P_Gate popups, therefore closes #54 
_This is similar to issue #50 for P_Alarm, which was resolved by similar pull request #53_ 