### PR TITLE
created .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Always use LF line endings for project script files. If this is not set, nuisance changes (line ending only) will be detected, causing resource.json files to update.
+ignition/script-python/** text eol=lf


### PR DESCRIPTION
Added .gitattributes file to ensure all line endings are checked in as LF

Also ensures that all project script files are checked out as LF, even on Windows, to avoid nuisance changes (line ending only) from being detected, causing resource.json files to update.
